### PR TITLE
Fix logo taking over the sidebar when Tailwind is loaded after the theme

### DIFF
--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -147,7 +147,7 @@ html[dir="rtl"] .hamburger-menu:before {
     }
 
     .bg-logo {
-        display: none;
+        display: none !important;
     }
 
     html:not([dir="rtl"]) .h-header .dropdown-trigger {


### PR DESCRIPTION
Nova ships with a slimed-down version of Tailwind (many rules are disabled), so it may desirable to include a full version. However, in such scenario the sidebar may break completely, depending on whether Tailwind loads before or after Nova Responsive Theme.

In the newest Nova releases, the sidebar logo has `.w-sidebar` class:

```php
{{-- vendor/laravel/nova/resources/views/layout.blade.php (fragment) --}}
<div class="min-h-screen flex-none pt-header min-h-screen w-sidebar bg-grad-sidebar px-6">
    <a href="{{ \Laravel\Nova\Nova::path() }}">
        <div class="absolute pin-t pin-l pin-r bg-logo flex items-center w-sidebar h-header px-6 text-white">
            @include('nova::partials.logo')
        </div>
    </a>

    @foreach (\Laravel\Nova\Nova::availableTools(request()) as $tool)
        {!! $tool->renderNavigation() !!}
    @endforeach
</div>
```

The theme sets logo's height to 100% (via `.w-sidebar`) and its `z-index` to some hight value,
so it is above the rest of the sidebar. That is normally not an issue, due to this rule:

```css
.bg-logo {
    display: none;
}
```

However, if Tailwind is loaded after the theme, the rule will conflict with Tailwind's
`.flex` rule (which has the same [specitifity](https://css-tricks.com/specifics-on-css-specificity/), so it "wins" by being declared later).

```css
.flex {
    display: flex;
}
```

And because of that, the logo gets `display: flex` and is visible on mobile, making
the sidebar unavailable (it hides the content, and even if set to transparent, still steals all the clicks).

![Screenshot from 2020-02-21 19-57-31](https://user-images.githubusercontent.com/8074163/75063118-7e82cf00-54e4-11ea-8d17-bda23fb8b9bc.png)

The proposed solution is to use `display: none !important;`. It may be worth considering whether to add `!important` to other similar rules, though I haven't found any other breakage yet.

A workaround for now is to set the order of service providers manually, to make the theme always load as the last CSS file. To do so, edit:

```php
// config/app.php
'providers' => [
    // all other providers...
    \Gregoriohc\LaravelNovaThemeResponsive\ThemeServiceProvider::class,
],
```

```js
// composer.json
"extra": {
    "laravel": {
        "dont-discover": [
            "gregoriohc/laravel-nova-theme-responsive"
        ]
    }
},
```

then drop the caches with `php artisan optimize:clear`.